### PR TITLE
Use a latest version of node-forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ejs": "~0.8.3",
     "async": "~0.2.7",
     "xpath": "0.0.5",
-    "node-forge": "0.2.24"
+    "node-forge": "0.6.38"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
use the latest version of node-forge to resolve the following error:

```sh
/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/util.js:1320
          _queryVariables = parse(window.location.search.substring(1));
                                                 ^

TypeError: Cannot read property 'search' of undefined
    at Object.util.getQueryVariables (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/util.js:1320:50)
    at Array.initModule (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/log.js:306:26)
    at Array.module.exports (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/log.js:359:14)
    at Module.module.exports (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:42:14)
    at defineFunc (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:48:10)
    at /Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:86:14
    at define (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:15:7)
    at define (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:55:22)
    at /Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:60:1
    at Object.<anonymous> (/Users/kklh716/az/kancho/web/rubix-3.0/node_modules/saml2-js/node_modules/xml-encryption/node_modules/node-forge/js/forge.js:88:3)

```