### PR TITLE
Fix autopadding issue with for 3DES algorithm

### DIFF
--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -10,13 +10,13 @@ function encryptKeyInfoWithScheme(symmetricKey, options, scheme, callback) {
     var rsa_pub = pki.publicKeyFromPem(options.rsa_pub);
     var encrypted = rsa_pub.encrypt(symmetricKey.toString('binary'), scheme);
     var base64EncodedEncryptedKey = new Buffer(encrypted, 'binary').toString('base64');
-    
+
     var params = {
       encryptedKey:  base64EncodedEncryptedKey,
       encryptionPublicCert: '<X509Data><X509Certificate>' + utils.pemToCert(options.pem.toString()) + '</X509Certificate></X509Data>',
       keyEncryptionMethod: options.keyEncryptionAlgorighm
     };
-    
+
     var result = utils.renderTemplate('keyinfo', params);
     callback(null, result);
   } catch (e) {
@@ -31,7 +31,7 @@ function encryptKeyInfo(symmetricKey, options, callback) {
     return callback(new Error('must provide options.rsa_pub with public key RSA'));
   if (!options.pem)
     return callback(new Error('must provide options.pem with certificate'));
-  
+
   if (!options.keyEncryptionAlgorighm)
     return callback(new Error('encryption without encrypted key is not supported yet'));
 
@@ -122,7 +122,7 @@ function decrypt(xml, options, callback) {
     return callback(new Error('must provide XML to encrypt'));
   if (!options.key)
     return callback(new Error('key option is mandatory and you should provide a valid RSA private key'));
-  
+
   var decrypted;
 
   try {
@@ -132,58 +132,48 @@ function decrypt(xml, options, callback) {
     var encryptionMethod = xpath.select("//*[local-name(.)='EncryptedData']/*[local-name(.)='EncryptionMethod']", doc)[0];
     var encryptionAlgorithm = encryptionMethod.getAttribute('Algorithm');
 
-    var decipher;
-    var padding;
+    var algorithm;
+    var ivLength;
     var encryptedContent = xpath.select("//*[local-name(.)='EncryptedData']/*[local-name(.)='CipherData']/*[local-name(.)='CipherValue']", doc)[0];
-    
+
     var encrypted = new Buffer(encryptedContent.textContent, 'base64');
-    
+
     switch (encryptionAlgorithm) {
       case 'http://www.w3.org/2001/04/xmlenc#aes128-cbc':
-        decipher = crypto.createDecipheriv('aes-128-cbc', symmetricKey, encrypted.slice(0, 16));
-
-        decipher.setAutoPadding(false);
-        decrypted = decipher.update(encrypted.slice(16), null, 'binary') + decipher.final('binary');
-
-        // Remove padding bytes equal to the value of the last byte of the returned data.
-        padding = decrypted.charCodeAt(decrypted.length - 1);
-        if (1 <= padding && padding <= 16) {
-          decrypted = decrypted.substr(0, decrypted.length - padding);
-        } else {
-          callback(new Error('padding length invalid'));
-          return;
-        }
-        
-        decrypted = new Buffer(decrypted, 'binary').toString('utf8');
+        algorithm = 'aes-128-cbc';
+        ivLength = 16;
         break;
       case 'http://www.w3.org/2001/04/xmlenc#aes256-cbc':
-        decipher = crypto.createDecipheriv('aes-256-cbc', symmetricKey, encrypted.slice(0, 16));
-
-        decipher.setAutoPadding(false);
-        decrypted = decipher.update(encrypted.slice(16), null, 'binary') + decipher.final('binary');
-
-        // Remove padding bytes equal to the value of the last byte of the returned data.
-        padding = decrypted.charCodeAt(decrypted.length - 1);
-        if (1 <= padding && padding <= 16) {
-          decrypted = decrypted.substr(0, decrypted.length - padding);
-        } else {
-          callback(new Error('padding length invalid'));
-          return;
-        }
-        decrypted = new Buffer(decrypted, 'binary').toString('utf8');
+        algorithm = 'aes-256-cbc';
+        ivLength = 16;
         break;
       case 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc':
-        decipher = crypto.createDecipheriv('des-ede3-cbc', symmetricKey, encrypted.slice(0,8));
-        decrypted = decipher.update(encrypted.slice(8), null, 'binary') + decipher.final('binary');
-        decrypted = new Buffer(decrypted, 'binary').toString('utf8');
+        algorithm = 'des-ede3-cbc';
+        ivLength = 8;
         break;
       default:
         return callback(new Error('encryption algorithm ' + encryptionAlgorithm + ' not supported'));
     }
+
+    var decipher = crypto.createDecipheriv(algorithm, symmetricKey, encrypted.slice(0,ivLength));
+    decipher.setAutoPadding(false);
+
+    decrypted = decipher.update(encrypted.slice(ivLength), null, 'binary') + decipher.final('binary');
+
+    // Remove padding bytes equal to the value of the last byte of the returned data.
+    var padding = decrypted.charCodeAt(decrypted.length - 1);
+    if (1 <= padding && padding <= ivLength) {
+      decrypted = decrypted.substr(0, decrypted.length - padding);
+    } else {
+      callback(new Error('padding length invalid'));
+      return;
+    }
+
+    decrypted = new Buffer(decrypted, 'binary').toString('utf8');
   } catch (e) {
     return callback(e);
   }
-  
+
   callback(null, decrypted);
 }
 
@@ -193,7 +183,7 @@ function decryptKeyInfo(doc, options) {
   var keyRetrievalMethodUri;
   var keyInfo = xpath.select("//*[local-name(.)='KeyInfo' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", doc)[0];
   var keyEncryptionMethod = xpath.select("//*[local-name(.)='KeyInfo']/*[local-name(.)='EncryptedKey']/*[local-name(.)='EncryptionMethod']", doc)[0];
-  
+
   if (!keyEncryptionMethod) { // try with EncryptedData->KeyInfo->RetrievalMethod
     var keyRetrievalMethod = xpath.select("//*[local-name(.)='EncryptedData']/*[local-name(.)='KeyInfo']/*[local-name(.)='RetrievalMethod']", doc)[0];
     keyRetrievalMethodUri = keyRetrievalMethod ? keyRetrievalMethod.getAttribute('URI') : null;
@@ -235,7 +225,7 @@ function encryptWithAlgorithm(algorithm, symmetricKey, ivLength, content, encodi
   // create a random iv for algorithm
   crypto.randomBytes(ivLength, function(err, iv) {
     if (err) return callback(err);
-    
+
     var cipher = crypto.createCipheriv(algorithm, symmetricKey, iv);
     // encrypted content
     var encrypted = cipher.update(content, encoding, 'binary') + cipher.final('binary');

--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -123,8 +123,6 @@ function decrypt(xml, options, callback) {
   if (!options.key)
     return callback(new Error('key option is mandatory and you should provide a valid RSA private key'));
 
-  var decrypted;
-
   try {
     var doc = typeof xml === 'string' ? new xmldom.DOMParser().parseFromString(xml) : xml;
 
@@ -132,49 +130,23 @@ function decrypt(xml, options, callback) {
     var encryptionMethod = xpath.select("//*[local-name(.)='EncryptedData']/*[local-name(.)='EncryptionMethod']", doc)[0];
     var encryptionAlgorithm = encryptionMethod.getAttribute('Algorithm');
 
-    var algorithm;
-    var ivLength;
     var encryptedContent = xpath.select("//*[local-name(.)='EncryptedData']/*[local-name(.)='CipherData']/*[local-name(.)='CipherValue']", doc)[0];
 
     var encrypted = new Buffer(encryptedContent.textContent, 'base64');
 
     switch (encryptionAlgorithm) {
       case 'http://www.w3.org/2001/04/xmlenc#aes128-cbc':
-        algorithm = 'aes-128-cbc';
-        ivLength = 16;
-        break;
+        return callback(null, decryptWithAlgorithm('aes-128-cbc', symmetricKey, 16, encrypted));
       case 'http://www.w3.org/2001/04/xmlenc#aes256-cbc':
-        algorithm = 'aes-256-cbc';
-        ivLength = 16;
-        break;
+        return callback(null, decryptWithAlgorithm('aes-256-cbc', symmetricKey, 16, encrypted));
       case 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc':
-        algorithm = 'des-ede3-cbc';
-        ivLength = 8;
-        break;
+        return callback(null, decryptWithAlgorithm('des-ede3-cbc', symmetricKey, 8, encrypted));
       default:
         return callback(new Error('encryption algorithm ' + encryptionAlgorithm + ' not supported'));
     }
-
-    var decipher = crypto.createDecipheriv(algorithm, symmetricKey, encrypted.slice(0,ivLength));
-    decipher.setAutoPadding(false);
-
-    decrypted = decipher.update(encrypted.slice(ivLength), null, 'binary') + decipher.final('binary');
-
-    // Remove padding bytes equal to the value of the last byte of the returned data.
-    var padding = decrypted.charCodeAt(decrypted.length - 1);
-    if (1 <= padding && padding <= ivLength) {
-      decrypted = decrypted.substr(0, decrypted.length - padding);
-    } else {
-      callback(new Error('padding length invalid'));
-      return;
-    }
-
-    decrypted = new Buffer(decrypted, 'binary').toString('utf8');
   } catch (e) {
     return callback(e);
   }
-
-  callback(null, decrypted);
 }
 
 function decryptKeyInfo(doc, options) {
@@ -231,6 +203,24 @@ function encryptWithAlgorithm(algorithm, symmetricKey, ivLength, content, encodi
     var encrypted = cipher.update(content, encoding, 'binary') + cipher.final('binary');
     return callback(null, Buffer.concat([iv, new Buffer(encrypted, 'binary')]));
   });
+}
+
+function decryptWithAlgorithm(algorithm, symmetricKey, ivLength, content) {
+  var decipher = crypto.createDecipheriv(algorithm, symmetricKey, content.slice(0,ivLength));
+  decipher.setAutoPadding(false);
+
+  var decrypted = decipher.update(content.slice(ivLength), null, 'binary') + decipher.final('binary');
+
+  // Remove padding bytes equal to the value of the last byte of the returned data.
+  var padding = decrypted.charCodeAt(decrypted.length - 1);
+  if (1 <= padding && padding <= ivLength) {
+    decrypted = decrypted.substr(0, decrypted.length - padding);
+  } else {
+    callback(new Error('padding length invalid'));
+    return;
+  }
+
+  return new Buffer(decrypted, 'binary').toString('utf8');
 }
 
 exports = module.exports = {

--- a/test/xmlenc.encryptedkey.js
+++ b/test/xmlenc.encryptedkey.js
@@ -12,7 +12,7 @@ describe('encrypt', function() {
     // cert created with:
     // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
     // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey 
+    // openssl x509 -in "test-auth0.pem" -pubkey
 
     var options = {
       rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
@@ -22,7 +22,7 @@ describe('encrypt', function() {
       keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     };
 
-    xmlenc.encrypt('content to encrypt', options, function(err, result) {  
+    xmlenc.encrypt('content to encrypt', options, function(err, result) {
       xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
         assert.equal(decrypted, 'content to encrypt');
         done();
@@ -34,7 +34,7 @@ describe('encrypt', function() {
     // cert created with:
     // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
     // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey 
+    // openssl x509 -in "test-auth0.pem" -pubkey
 
     var options = {
       rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
@@ -44,7 +44,7 @@ describe('encrypt', function() {
       keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     };
 
-    xmlenc.encrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', options, function(err, result) {  
+    xmlenc.encrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', options, function(err, result) {
       xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
         assert.equal(decrypted, 'Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge');
         done();
@@ -56,7 +56,7 @@ describe('encrypt', function() {
     // cert created with:
     // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
     // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey 
+    // openssl x509 -in "test-auth0.pem" -pubkey
 
     var options = {
       rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
@@ -95,7 +95,7 @@ describe('encrypt', function() {
     // cert created with:
     // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
     // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey 
+    // openssl x509 -in "test-auth0.pem" -pubkey
 
     var options = {
       rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
@@ -105,13 +105,35 @@ describe('encrypt', function() {
       keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
     };
 
-    xmlenc.encrypt('content to encrypt', options, function(err, result) {  
+    xmlenc.encrypt('content to encrypt', options, function(err, result) {
       xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
         assert.equal(decrypted, 'content to encrypt');
         done();
       });
     });
   });
+
+  it('should encrypt and decrypt xml (encryption: http://www.w3.org/2001/04/xmlenc#tripledes-cbc, keyEncryption: http://www.w3.org/2001/04/xmlenc#rsa-1_5)', function (done) {
+      // cert created with:
+      // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
+      // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
+      // openssl x509 -in "test-auth0.pem" -pubkey
+
+      var options = {
+        rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+        pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
+        key: fs.readFileSync(__dirname + '/test-auth0.key'),
+        encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc',
+        keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
+      };
+
+      xmlenc.encrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', options, function (err, result) {
+        xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function (err, decrypted) {
+          assert.equal(decrypted, 'Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge');
+          done();
+        });
+      });
+    });
 
   it('should encrypt and decrypt keyinfo', function (done) {
     var options = {
@@ -122,7 +144,7 @@ describe('encrypt', function() {
 
     crypto.randomBytes(32, function(err, randomBytes) {
       if (err) return done(err);
-      xmlenc.encryptKeyInfo(randomBytes, options, function(err, result) { 
+      xmlenc.encryptKeyInfo(randomBytes, options, function(err, result) {
         if (err) return done(err);
         var decryptedRandomBytes = xmlenc.decryptKeyInfo(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')});
 

--- a/test/xmlenc.encryptedkey.js
+++ b/test/xmlenc.encryptedkey.js
@@ -8,132 +8,55 @@ var xpath = require('xpath');
 
 describe('encrypt', function() {
 
-  it('should encrypt and decrypt xml (aes256-cbc)', function (done) {
-    // cert created with:
-    // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
-    // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey
-
-    var options = {
-      rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-      pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
+  var algorithms = [{
+    name: 'aes-256-cbc',
+    encryptionOptions: {
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
       keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-    };
-
-    xmlenc.encrypt('content to encrypt', options, function(err, result) {
-      xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-        assert.equal(decrypted, 'content to encrypt');
-        done();
-      });
-    });
-  });
-
-  it('should encrypt and decrypt xml (aes256-cbc with utf8 chars)', function (done) {
-    // cert created with:
-    // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
-    // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey
-
-    var options = {
-      rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-      pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-    };
-
-    xmlenc.encrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', options, function(err, result) {
-      xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-        assert.equal(decrypted, 'Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge');
-        done();
-      });
-    });
-  });
-
-  it('should encrypt and decrypt xml (aes128-cbc) with utf8 chars', function (done) {
-    // cert created with:
-    // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
-    // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey
-
-    var options = {
-      rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-      pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
+    }
+  }, {
+    name: 'aes-128-cbc',
+    encryptionOptions: {
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes128-cbc',
       keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-    };
-
-    xmlenc.encrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', options, function (err, result) {
-      xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function (err, decrypted) {
-        assert.equal(decrypted, 'Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge');
-        done();
-      });
-    });
-  });
-
-  it('should encrypt and decrypt xml (aes128-cbc)', function (done) {
-    var options = {
-      rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-      pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes128-cbc',
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-    };
-
-    xmlenc.encrypt('content to encrypt', options, function (err, result) {
-      xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function (err, decrypted) {
-        assert.equal(decrypted, 'content to encrypt');
-        done();
-      });
-    });
-  });
-
-  it('should encrypt and decrypt xml (encryption: http://www.w3.org/2001/04/xmlenc#tripledes-cbc, keyEncryption: http://www.w3.org/2001/04/xmlenc#rsa-1_5)', function (done) {
-    // cert created with:
-    // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
-    // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-    // openssl x509 -in "test-auth0.pem" -pubkey
-
-    var options = {
-      rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-      pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
+    }
+  }, {
+    name: 'des-ede3-cbc',
+    encryptionOptions: {
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc',
       keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
-    };
+    }
+  }];
 
-    xmlenc.encrypt('content to encrypt', options, function(err, result) {
-      xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-        assert.equal(decrypted, 'content to encrypt');
-        done();
+  algorithms.forEach(function (algorithm) {
+    describe(algorithm.name, function () {
+      it('should encrypt and decrypt xml', function (done) {
+        _shouldEncryptAndDecrypt('content to encrypt', algorithm.encryptionOptions, done);
+      });
+
+      it('should encrypt and decrypt xml with utf8 chars', function (done) {
+        _shouldEncryptAndDecrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', algorithm.encryptionOptions, done);
       });
     });
   });
 
-  it('should encrypt and decrypt xml (encryption: http://www.w3.org/2001/04/xmlenc#tripledes-cbc, keyEncryption: http://www.w3.org/2001/04/xmlenc#rsa-1_5)', function (done) {
-      // cert created with:
-      // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
-      // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
-      // openssl x509 -in "test-auth0.pem" -pubkey
+  function _shouldEncryptAndDecrypt(content, options, done) {
+    // cert created with:
+    // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
+    // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
+    // openssl x509 -in "test-auth0.pem" -pubkey
 
-      var options = {
-        rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-        pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        key: fs.readFileSync(__dirname + '/test-auth0.key'),
-        encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc',
-        keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
-      };
+    options.rsa_pub = fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+    options.pem = fs.readFileSync(__dirname + '/test-auth0.pem'),
+    options.key = fs.readFileSync(__dirname + '/test-auth0.key'),
 
-      xmlenc.encrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', options, function (err, result) {
-        xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function (err, decrypted) {
-          assert.equal(decrypted, 'Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge');
-          done();
-        });
+    xmlenc.encrypt(content, options, function(err, result) {
+      xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function (err, decrypted) {
+        assert.equal(decrypted, content);
+        done();
       });
     });
+  }
 
   it('should encrypt and decrypt keyinfo', function (done) {
     var options = {


### PR DESCRIPTION
Onelogin uses triple DES encryption algorithm to encrypt their SAML response and xml-encryption fails to decrypt the response (issue solution described here: https://github.com/nodejs/node/issues/2794#issuecomment-139436581)
This PR applies de1ec53b8e0ff3f59a55c14abf5516f9b115ca31 and 26c391699a7e4bffac63b22ada47f309e06c70ac for 3DES algorithm.
I also DRYed the decrypt code and unit tests.
