### PR TITLE
Setting decipher.setAutoPadding(false);

### DIFF
--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -174,6 +174,7 @@ function decrypt(xml, options, callback) {
         break;
       case 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc':
         decipher = crypto.createDecipheriv('des-ede3-cbc', symmetricKey, encrypted.slice(0,8));
+        decipher.setAutoPadding(false);
         decrypted = decipher.update(encrypted.slice(8), null, 'binary') + decipher.final('binary');
         decrypted = new Buffer(decrypted, 'binary').toString('utf8');
         break;


### PR DESCRIPTION
I'm not sure why `decipher.setAutoPadding(false);` was excluded from 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc', or indeed included in the others. I do know that this resolves an issue decrypting the IDP's response which i'm working on at the moment.