### PR TITLE
KeyInfo element is optional in spec but enforced in project

### DIFF
--- a/lib/templates/keyinfo.tpl.xml
+++ b/lib/templates/keyinfo.tpl.xml
@@ -3,9 +3,7 @@
     <e:EncryptionMethod Algorithm="<%= keyEncryptionMethod %>">
       <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
     </e:EncryptionMethod>
-    <KeyInfo>
-      <%- encryptionPublicCert %>
-    </KeyInfo>
+    <%- encryptionPublicCert %>
     <e:CipherData>
       <e:CipherValue><%= encryptedKey %></e:CipherValue>
     </e:CipherData>

--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -13,7 +13,7 @@ function encryptKeyInfoWithScheme(symmetricKey, options, scheme, callback) {
 
     var params = {
       encryptedKey:  base64EncodedEncryptedKey,
-      encryptionPublicCert: '<X509Data><X509Certificate>' + utils.pemToCert(options.pem.toString()) + '</X509Certificate></X509Data>',
+      encryptionPublicCert: options.pem ? ('<KeyInfo><X509Data><X509Certificate>' + utils.pemToCert(options.pem.toString()) + '</X509Certificate></X509Data></KeyInfo>') : '',
       keyEncryptionMethod: options.keyEncryptionAlgorighm
     };
 
@@ -29,8 +29,6 @@ function encryptKeyInfo(symmetricKey, options, callback) {
     return callback(new Error('must provide options'));
   if (!options.rsa_pub)
     return callback(new Error('must provide options.rsa_pub with public key RSA'));
-  if (!options.pem)
-    return callback(new Error('must provide options.pem with certificate'));
 
   if (!options.keyEncryptionAlgorighm)
     return callback(new Error('encryption without encrypted key is not supported yet'));
@@ -54,8 +52,6 @@ function encrypt(content, options, callback) {
     return callback(new Error('must provide content to encrypt'));
   if (!options.rsa_pub)
     return callback(new Error('rsa_pub option is mandatory and you should provide a valid RSA public key'));
-  if (!options.pem)
-    return callback(new Error('pem option is mandatory and you should provide a valid x509 certificate encoded as PEM'));
 
   options.input_encoding = options.input_encoding || 'utf8';
 
@@ -119,7 +115,7 @@ function decrypt(xml, options, callback) {
   if (!options)
     return callback(new Error('must provide options'));
   if (!xml)
-    return callback(new Error('must provide XML to encrypt'));
+    return callback(new Error('must provide XML to decrypt'));
   if (!options.key)
     return callback(new Error('key option is mandatory and you should provide a valid RSA private key'));
 

--- a/test/xmlenc.encryptedkey.js
+++ b/test/xmlenc.encryptedkey.js
@@ -34,8 +34,16 @@ describe('encrypt', function() {
         _shouldEncryptAndDecrypt('content to encrypt', algorithm.encryptionOptions, done);
       });
 
+      it('should encrypt and decrypt xml when no x509 cert present', function (done) {
+        _shouldEncryptAndDecryptNoX509('content to encrypt', algorithm.encryptionOptions, done);
+      });
+
       it('should encrypt and decrypt xml with utf8 chars', function (done) {
         _shouldEncryptAndDecrypt('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', algorithm.encryptionOptions, done);
+      });
+
+      it('should encrypt and decrypt xml with utf8 chars when no x509 cert present', function (done) {
+        _shouldEncryptAndDecryptNoX509('Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge Gnügge', algorithm.encryptionOptions, done);
       });
     });
   });
@@ -48,6 +56,24 @@ describe('encrypt', function() {
 
     options.rsa_pub = fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
     options.pem = fs.readFileSync(__dirname + '/test-auth0.pem'),
+    options.key = fs.readFileSync(__dirname + '/test-auth0.key'),
+
+    xmlenc.encrypt(content, options, function(err, result) {
+      xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function (err, decrypted) {
+        assert.equal(decrypted, content);
+        done();
+      });
+    });
+  }
+
+  function _shouldEncryptAndDecryptNoX509(content, options, done) {
+    // cert created with:
+    // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
+    // pub key extracted from (only the RSA public key between BEGIN PUBLIC KEY and END PUBLIC KEY)
+    // openssl x509 -in "test-auth0.pem" -pubkey
+
+    options.rsa_pub = fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+    // options.pem = fs.readFileSync(__dirname + '/test-auth0.pem'),
     options.key = fs.readFileSync(__dirname + '/test-auth0.key'),
 
     xmlenc.encrypt(content, options, function(err, result) {


### PR DESCRIPTION
[The spec](https://www.w3.org/TR/xmldsig-core/#sec-KeyInfo) says, "KeyInfo is an optional element that … ".  However, `options.pem` is a mandatory parameter.

I have a use case where the <KeyInfo> element is not used so I've created this PR.
