### PR TITLE
Make sure that Node 6-8 is supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - 0.10
+  - 4
+  - 6
+  - 8

--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -182,15 +182,10 @@ function decryptKeyInfo(doc, options) {
 }
 
 function decryptKeyInfoWithScheme(encryptedKey, options, scheme) {
-  try {
-    var key = new Buffer(encryptedKey.textContent, 'base64').toString('binary');
-    var private_key = pki.privateKeyFromPem(options.key);
-    var decrypted = private_key.decrypt(key, scheme);
-    return new Buffer(decrypted, 'binary');
-  }
-  catch (e) {
-    throw e;
-  }
+  var key = new Buffer(encryptedKey.textContent, 'base64').toString('binary');
+  var private_key = pki.privateKeyFromPem(options.key);
+  var decrypted = private_key.decrypt(key, scheme);
+  return new Buffer(decrypted, 'binary');
 }
 
 function encryptWithAlgorithm(algorithm, symmetricKey, ivLength, content, encoding, callback) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xml-encryption",
   "version": "0.11.0",
   "devDependencies": {
-    "mocha": "*",
+    "mocha": "3.3.0",
     "should": "^11.2.1"
   },
   "main": "./lib",

--- a/test/xmlenc.encryptedkey.js
+++ b/test/xmlenc.encryptedkey.js
@@ -1,9 +1,6 @@
-var assert = require('assert'),
-    fs = require('fs'),
-    xmlenc = require('../lib');
-
-var crypto = require('crypto');
-var xmldom = require('xmldom');
+var assert = require('assert');
+var fs = require('fs');
+var xmlenc = require('../lib');
 var xpath = require('xpath');
 
 describe('encrypt', function() {
@@ -65,15 +62,18 @@ describe('encrypt', function() {
       keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     };
 
-    crypto.randomBytes(32, function(err, randomBytes) {
-      if (err) return done(err);
-      xmlenc.encryptKeyInfo(randomBytes, options, function(err, result) {
-        if (err) return done(err);
-        var decryptedRandomBytes = xmlenc.decryptKeyInfo(result, { key: fs.readFileSync(__dirname + '/test-auth0.key')});
+    var plaintext = 'The quick brown fox jumps over the lazy dog';
 
-        assert.equal(new Buffer(randomBytes).toString('base64'), new Buffer(decryptedRandomBytes).toString('base64'));
-        done();
-      });
+    xmlenc.encryptKeyInfo(plaintext, options, function(err, encryptedKeyInfo) {
+      if (err) return done(err);
+
+      var decryptedKeyInfo = xmlenc.decryptKeyInfo(
+        encryptedKeyInfo,
+        {key: fs.readFileSync(__dirname + '/test-auth0.key')}
+      );
+      assert.equal(decryptedKeyInfo.toString(), plaintext);
+
+      done();
     });
   });
 


### PR DESCRIPTION
We want to make sure that Node 6 and 8 are supported today, and as future changes are introduced.

Given [the changes to the default encoding in the cryptographic functions introduced in Node 6](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#crypto), I wasn't sure if `xmlenc.decryptKeyInfo()` worked properly in Node 6.