### PR TITLE
Fix typo for keyEncryptionAlgorithm option

### DIFF
--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -18,7 +18,7 @@ function encryptKeyInfoWithScheme(symmetricKey, options, scheme, callback) {
     var params = {
       encryptedKey:  base64EncodedEncryptedKey,
       encryptionPublicCert: '<X509Data><X509Certificate>' + utils.pemToCert(options.pem.toString()) + '</X509Certificate></X509Data>',
-      keyEncryptionMethod: options.keyEncryptionAlgorighm
+      keyEncryptionMethod: options.keyEncryptionAlgorithm
     };
 
     var result = utils.renderTemplate('keyinfo', params);
@@ -36,13 +36,13 @@ function encryptKeyInfo(symmetricKey, options, callback) {
   if (!options.pem)
     return callback(new Error('must provide options.pem with certificate'));
 
-  if (!options.keyEncryptionAlgorighm)
+  if (!options.keyEncryptionAlgorithm)
     return callback(new Error('encryption without encrypted key is not supported yet'));
   if (options.disallowEncryptionWithInsecureAlgorithm
-    && insecureAlgorithms.indexOf(options.keyEncryptionAlgorighm) >= 0) {
-    return callback(new Error('encryption algorithm ' + options.keyEncryptionAlgorighm + 'is not secure'));
+    && insecureAlgorithms.indexOf(options.keyEncryptionAlgorithm) >= 0) {
+    return callback(new Error('encryption algorithm ' + options.keyEncryptionAlgorithm + 'is not secure'));
   }
-  switch (options.keyEncryptionAlgorighm) {
+  switch (options.keyEncryptionAlgorithm) {
     case 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p':
       return encryptKeyInfoWithScheme(symmetricKey, options, 'RSA-OAEP', callback);
 
@@ -64,8 +64,8 @@ function encrypt(content, options, callback) {
   if (!options.pem)
     return callback(new Error('pem option is mandatory and you should provide a valid x509 certificate encoded as PEM'));
   if (options.disallowEncryptionWithInsecureAlgorithm
-    && insecureAlgorithms.indexOf(options.keyEncryptionAlgorighm) >= 0) {
-    return callback(new Error('encryption algorithm ' + options.keyEncryptionAlgorighm + 'is not secure'));
+    && insecureAlgorithms.indexOf(options.keyEncryptionAlgorithm) >= 0) {
+    return callback(new Error('encryption algorithm ' + options.keyEncryptionAlgorithm + 'is not secure'));
   }
   options.input_encoding = options.input_encoding || 'utf8';
 
@@ -217,7 +217,7 @@ function decryptKeyInfo(doc, options) {
     case 'http://www.w3.org/2001/04/xmlenc#rsa-1_5':
       return decryptKeyInfoWithScheme(encryptedKey, options, 'RSAES-PKCS1-V1_5');
     default:
-      throw new Error('key encryption algorithm ' + keyEncryptionAlgorighm + ' not supported');
+      throw new Error('key encryption algorithm ' + keyEncryptionAlgorithm + ' not supported');
   }
 }
 

--- a/test/xmlenc.encryptedkey.js
+++ b/test/xmlenc.encryptedkey.js
@@ -9,19 +9,19 @@ describe('encrypt', function() {
     name: 'aes-256-cbc',
     encryptionOptions: {
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     }
   }, {
     name: 'aes-128-cbc',
     encryptionOptions: {
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes128-cbc',
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     }
   }, {
     name: 'des-ede3-cbc',
     encryptionOptions: {
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc',
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
     }
   }];
 
@@ -63,10 +63,10 @@ describe('encrypt', function() {
       key: fs.readFileSync(__dirname + '/test-auth0.key'),
       disallowInsecureEncryptionAlgorithm: true,
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes128-cbc',
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     }
       //options.encryptionAlgorithm = 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc',
-      //options.keyEncryptionAlgorighm = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5';
+      //options.keyEncryptionAlgorithm = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5';
       xmlenc.encrypt('encrypt me', options, function(err, result) {
         assert(err);
         done();
@@ -79,7 +79,7 @@ describe('encrypt', function() {
       pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
       key: fs.readFileSync(__dirname + '/test-auth0.key'),
       encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes128-cbc',
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
       }
       xmlenc.encrypt('encrypt me', options, function(err, result) {
         xmlenc.decrypt(result,
@@ -98,7 +98,7 @@ describe('encrypt', function() {
     var options = {
       rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
       pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     };
 
     var plaintext = 'The quick brown fox jumps over the lazy dog';
@@ -137,7 +137,7 @@ describe('encrypt', function() {
     var options = {
       rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
       pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5',
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5',
       disallowInsecureEncryptionAlgorithm: true
     };
 
@@ -153,7 +153,7 @@ describe('encrypt', function() {
     var options = {
       rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
       pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      keyEncryptionAlgorighm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-1_5'
     };
 
     var plaintext = 'The quick brown fox jumps over the lazy dog';


### PR DESCRIPTION
### Description
Fix typo for options.keyEncryptionAlgorithm. 

🚫 This requires a major version bump due to backwards incompatible change. 

### Testing

- [x]  existing unit tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
