### PR TITLE
Deprecate node 4/6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 W3C XML Encryption implementation for node.js (http://www.w3.org/TR/xmlenc-core/)
 
+Supports node >= 8
+
 ## Usage
 
     npm install xml-encryption

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "test": "mocha"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   }
 }


### PR DESCRIPTION

### Description

Deprecating support for node 4 and 6. 

### References

https://github.com/auth0/node-xml-encryption/pull/59

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
