### PR TITLE
Update node-forge to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xml-encryption",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -683,9 +683,9 @@
       }
     },
     "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "escape-html": "^1.0.3",
-    "node-forge": "^0.7.0",
+    "node-forge": "^0.10.0",
     "xmldom": "~0.1.15",
     "xpath": "0.0.27"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xml-encryption",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "devDependencies": {
     "mocha": "^7.1.2",
     "should": "^11.2.1",


### PR DESCRIPTION
### Description

Updates `node-forge` to the latest version to address a security issue in the dependency and bumps a new version. Fixes #75  

The `node-forge` new version drops support for node 4 but `node-xml-encryption` already specifies the node engine >=8. As such, a new patch version will be released.


### References

https://snyk.io/vuln/SNYK-JS-NODEFORGE-598677 

### Testing

All tests pass successfully. 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
