### PR TITLE
Replace node-forge by native node crypto.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 W3C XML Encryption implementation for node.js (http://www.w3.org/TR/xmlenc-core/)
 
-Supports node >= 8
+Supports node >= 12
 
 ## Usage
 

--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -2,18 +2,23 @@ var crypto  = require('crypto');
 var xmldom  = require('@xmldom/xmldom');
 var xpath   = require('xpath');
 var utils   = require('./utils');
-var pki     = require('node-forge').pki;
 
 const insecureAlgorithms = [
   //https://www.w3.org/TR/xmlenc-core1/#rsav15note
   'http://www.w3.org/2001/04/xmlenc#rsa-1_5',
   //https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA
   'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'];
+
 function encryptKeyInfoWithScheme(symmetricKey, options, scheme, callback) {
+  const padding = scheme === 'RSA-OAEP' ? crypto.constants.RSA_PKCS1_OAEP_PADDING : crypto.constants.RSA_PKCS1_PADDING;
+  const symmetricKeyBuffer = Buffer.isBuffer(symmetricKey) ? symmetricKey : Buffer.from(symmetricKey, 'utf-8');
+
   try {
-    var rsa_pub = pki.publicKeyFromPem(options.rsa_pub);
-    var encrypted = rsa_pub.encrypt(symmetricKey.toString('binary'), scheme);
-    var base64EncodedEncryptedKey = Buffer.from(encrypted, 'binary').toString('base64');
+    var encrypted = crypto.publicEncrypt({
+      key: options.rsa_pub,
+      padding: padding
+    }, symmetricKeyBuffer);
+    var base64EncodedEncryptedKey = encrypted.toString('base64');
 
     var params = {
       encryptedKey:  base64EncodedEncryptedKey,
@@ -248,9 +253,9 @@ function decryptKeyInfo(doc, options) {
 }
 
 function decryptKeyInfoWithScheme(encryptedKey, options, scheme) {
-  var key = Buffer.from(encryptedKey.textContent, 'base64').toString('binary');
-  var private_key = pki.privateKeyFromPem(options.key);
-  var decrypted = private_key.decrypt(key, scheme);
+  var padding = scheme === 'RSA-OAEP' ? crypto.constants.RSA_PKCS1_OAEP_PADDING : crypto.constants.RSA_PKCS1_PADDING;
+  var key = Buffer.from(encryptedKey.textContent, 'base64');
+  var decrypted = crypto.privateDecrypt({ key: options.key, padding: padding}, key);
   return Buffer.from(decrypted, 'binary');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -687,11 +687,6 @@
         "semver": "^5.7.0"
       }
     },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@xmldom/xmldom": "^0.7.0",
     "escape-html": "^1.0.3",
-    "node-forge": "^0.10.0",
     "xpath": "0.0.32"
   },
   "files": [


### PR DESCRIPTION
This requires dropping support for node 8, which is probably fine since
node 8 is EoL since December 31, 2019.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Drop node-forge (which is a huge dep), use native nodejs crypto.

### References

About node 8 support
https://blog.risingstack.com/update-nodejs-8-end-of-life-no-support/

Node Crypto
https://nodejs.org/api/crypto.html#crypto_crypto_publicencrypt_key_buffer
https://nodejs.org/api/crypto.html#crypto_crypto_privatedecrypt_privatekey_buffer

### Testing

I updated first the encryption part, ran the tests (it was fine) then the decryption part (tests still fine).
This made sure the new encryption works well with the

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
