### PR TITLE
Update xmldom to 0.7.0

### DIFF
--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -1,5 +1,5 @@
 var crypto  = require('crypto');
-var xmldom  = require('xmldom');
+var xmldom  = require('@xmldom/xmldom');
 var xpath   = require('xpath');
 var utils   = require('./utils');
 var pki     = require('node-forge').pki;

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@xmldom/xmldom": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.0.tgz",
+      "integrity": "sha512-imgPU2uvItdwBSO/q/k/pntmrYm/bjiD3Xs6O2daALR1lBjif7JVxS1RYAwTcYxZUPHeBAoiKUcGpyCD9+MRRg=="
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -1054,11 +1059,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@xmldom/xmldom": "^0.7.0",
     "escape-html": "^1.0.3",
     "node-forge": "^0.10.0",
-    "xmldom": "~0.6.0",
     "xpath": "0.0.32"
   },
   "files": [

--- a/test/xmlenc.integration.js
+++ b/test/xmlenc.integration.js
@@ -3,7 +3,7 @@ var assert = require('assert'),
     xmlenc = require('../lib');
 
 var crypto = require('crypto');
-var xmldom = require('xmldom');
+var xmldom = require('@xmldom/xmldom');
 var xpath = require('xpath');
 
 describe('integration', function() {


### PR DESCRIPTION
The package is now scoped under @xmldom. See https://github.com/xmldom/xmldom/pull/278
This fixes security vulnerability CVE-2021-32796

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes CVE-2021-32796

### References

https://nvd.nist.gov/vuln/detail/CVE-2021-32796
https://snyk.io/vuln/SNYK-JS-XMLDOM-1534562
https://github.com/xmldom/xmldom/pull/278

### Testing

Tests pass

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
