### PR TITLE
Bump @xmldom/xmldom to 0.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "xml-encryption",
-      "version": "2.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.3",
+        "@xmldom/xmldom": "^0.8.5",
         "escape-html": "^1.0.3",
         "xpath": "0.0.32"
       },
@@ -73,9 +73,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1644,9 +1644,9 @@
       "dev": true
     },
     "@xmldom/xmldom": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ=="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ=="
     },
     "ansi-colors": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@xmldom/xmldom": "^0.8.3",
+    "@xmldom/xmldom": "^0.8.5",
     "escape-html": "^1.0.3",
     "xpath": "0.0.32"
   },


### PR DESCRIPTION
### Description

Bump @xmldom/xmldom to 0.8.5 to remediate a [security advisory](https://github.com/xmldom/xmldom/security/advisories/GHSA-crh6-fp67-6883)

### References

Closes #102 

### Testing

Per unit tests

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
