### PR TITLE
add test to github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Build and Test
+
+on:
+  merge_group:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 12, 14, 16, 18 ]
+    name: Node ${{ matrix.node }} Test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --build-from-source
+
+      - name: Run Jest unit tests
+        run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,4 @@ jobs:
 
       - name: Run Mocha unit tests
         run: npm run test
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install --build-from-source
+        run: npm ci
 
-      - name: Run Jest unit tests
+      - name: Run Mocha unit tests
         run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 12, 14, 16, 18 ]
+        node: [ 12, 14, 16 ]
     name: Node ${{ matrix.node }} Test
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 W3C XML Encryption implementation for node.js (http://www.w3.org/TR/xmlenc-core/)
 
-Supports node >= 12
+Supports node >= 12 < 18
+
+node 18 not supported due to https://github.com/nodejs/node/issues/52017 for Triple DES algorithms.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "test": "mocha"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=12 < 18"
   }
 }


### PR DESCRIPTION
### Description

Add test runs during PR merge. 
Also updated the README on node version support. 

### References

Node 18 does not support triple des algorithm (listed as insecure) due to 

>  TypeError: RSA_PKCS1_PADDING is no longer supported for private decryption, this can be reverted with --security-revert=CVE-2023-46809
