### PR TITLE
Add support for sha256/512 encryption key OAEP digest methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 [![Build Status](https://travis-ci.org/auth0/node-xml-encryption.png)](https://travis-ci.org/auth0/node-xml-encryption)
 
-W3C XML Encryption implementation for node.js (http://www.w3.org/TR/xmlenc-core/)
+W3C XML Encryption implementation for Node.js (http://www.w3.org/TR/xmlenc-core/)
 
-Supports node >= 12 < 18
-
-node 18 not supported due to https://github.com/nodejs/node/issues/52017 for Triple DES algorithms.
+Node 18+ does not support Triple DES algorithms due to https://github.com/nodejs/node/issues/52017
 
 ## Usage
 
@@ -20,6 +18,7 @@ var options = {
   pem: fs.readFileSync(__dirname + '/your_public_cert.pem'),
   encryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
   keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+  keyEncryptionDigest: 'sha1',
   disallowEncryptionWithInsecureAlgorithm: true,
   warnInsecureAlgorithm: true
 };

--- a/lib/templates/keyinfo.tpl.xml.js
+++ b/lib/templates/keyinfo.tpl.xml.js
@@ -1,10 +1,10 @@
 var escapehtml = require('escape-html');
 
-module.exports = ({ encryptionPublicCert, encryptedKey, keyEncryptionMethod }) => `
+module.exports = ({ encryptionPublicCert, encryptedKey, keyEncryptionMethod, keyEncryptionDigest }) => `
 <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
   <e:EncryptedKey xmlns:e="http://www.w3.org/2001/04/xmlenc#">
     <e:EncryptionMethod Algorithm="${escapehtml(keyEncryptionMethod)}">
-      <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
+      <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#${escapehtml(keyEncryptionDigest)}" />
     </e:EncryptionMethod>
     <KeyInfo>
       ${encryptionPublicCert}

--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -9,13 +9,13 @@ const insecureAlgorithms = [
   //https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA
   'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'];
 
-function encryptKeyInfoWithScheme(symmetricKey, options, scheme, callback) {
-  const padding = scheme === 'RSA-OAEP' ? crypto.constants.RSA_PKCS1_OAEP_PADDING : crypto.constants.RSA_PKCS1_PADDING;
+function encryptKeyInfoWithScheme(symmetricKey, options, padding, callback) {
   const symmetricKeyBuffer = Buffer.isBuffer(symmetricKey) ? symmetricKey : Buffer.from(symmetricKey, 'utf-8');
 
   try {
     var encrypted = crypto.publicEncrypt({
       key: options.rsa_pub,
+      oaepHash: padding == crypto.constants.RSA_PKCS1_OAEP_PADDING ? options.keyEncryptionDigest : undefined,
       padding: padding
     }, symmetricKeyBuffer);
     var base64EncodedEncryptedKey = encrypted.toString('base64');
@@ -23,7 +23,8 @@ function encryptKeyInfoWithScheme(symmetricKey, options, scheme, callback) {
     var params = {
       encryptedKey:  base64EncodedEncryptedKey,
       encryptionPublicCert: '<X509Data><X509Certificate>' + utils.pemToCert(options.pem.toString()) + '</X509Certificate></X509Data>',
-      keyEncryptionMethod: options.keyEncryptionAlgorithm
+      keyEncryptionMethod: options.keyEncryptionAlgorithm,
+      keyEncryptionDigest: options.keyEncryptionDigest,
     };
 
     var result = utils.renderTemplate('keyinfo', params);
@@ -47,13 +48,14 @@ function encryptKeyInfo(symmetricKey, options, callback) {
     && insecureAlgorithms.indexOf(options.keyEncryptionAlgorithm) >= 0) {
     return callback(new Error('encryption algorithm ' + options.keyEncryptionAlgorithm + 'is not secure'));
   }
+  options.keyEncryptionDigest = options.keyEncryptionDigest || 'sha1';
   switch (options.keyEncryptionAlgorithm) {
     case 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p':
-      return encryptKeyInfoWithScheme(symmetricKey, options, 'RSA-OAEP', callback);
+      return encryptKeyInfoWithScheme(symmetricKey, options, crypto.constants.RSA_PKCS1_OAEP_PADDING, callback);
 
     case 'http://www.w3.org/2001/04/xmlenc#rsa-1_5':
       utils.warnInsecureAlgorithm(options.keyEncryptionAlgorithm, options.warnInsecureAlgorithm);
-      return encryptKeyInfoWithScheme(symmetricKey, options, 'RSAES-PKCS1-V1_5', callback);
+      return encryptKeyInfoWithScheme(symmetricKey, options, crypto.constants.RSA_PKCS1_PADDING, callback);
 
     default:
       return callback(new Error('encryption key algorithm not supported'));
@@ -235,6 +237,20 @@ function decryptKeyInfo(doc, options) {
     throw new Error('cant find encryption algorithm');
   }
 
+  let oaepHash = 'sha1';
+  const keyDigestMethod = xpath.select("//*[local-name(.)='KeyInfo']/*[local-name(.)='EncryptedKey']/*[local-name(.)='EncryptionMethod']/*[local-name(.)='DigestMethod']", doc)[0];
+  if (keyDigestMethod) {
+    const keyDigestMethodAlgorithm = keyDigestMethod.getAttribute('Algorithm');
+    switch (keyDigestMethodAlgorithm) {
+      case 'http://www.w3.org/2000/09/xmldsig#sha256':
+        oaepHash = 'sha256';
+        break;
+      case 'http://www.w3.org/2000/09/xmldsig#sha512':
+        oaepHash = 'sha512';
+        break;
+    }
+  }
+
   var keyEncryptionAlgorithm = keyEncryptionMethod.getAttribute('Algorithm');
   if (options.disallowDecryptionWithInsecureAlgorithm
     && insecureAlgorithms.indexOf(keyEncryptionAlgorithm) >= 0) {
@@ -246,19 +262,18 @@ function decryptKeyInfo(doc, options) {
 
   switch (keyEncryptionAlgorithm) {
     case 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p':
-      return decryptKeyInfoWithScheme(encryptedKey, options, 'RSA-OAEP');
+      return decryptKeyInfoWithScheme(encryptedKey, options, crypto.constants.RSA_PKCS1_OAEP_PADDING, oaepHash);
     case 'http://www.w3.org/2001/04/xmlenc#rsa-1_5':
       utils.warnInsecureAlgorithm(keyEncryptionAlgorithm, options.warnInsecureAlgorithm);
-      return decryptKeyInfoWithScheme(encryptedKey, options, 'RSAES-PKCS1-V1_5');
+      return decryptKeyInfoWithScheme(encryptedKey, options, crypto.constants.RSA_PKCS1_PADDING);
     default:
       throw new Error('key encryption algorithm ' + keyEncryptionAlgorithm + ' not supported');
   }
 }
 
-function decryptKeyInfoWithScheme(encryptedKey, options, scheme) {
-  var padding = scheme === 'RSA-OAEP' ? crypto.constants.RSA_PKCS1_OAEP_PADDING : crypto.constants.RSA_PKCS1_PADDING;
-  var key = Buffer.from(encryptedKey.textContent, 'base64');
-  var decrypted = crypto.privateDecrypt({ key: options.key, padding: padding}, key);
+function decryptKeyInfoWithScheme(encryptedKey, options, padding, oaepHash) {
+  const key = Buffer.from(encryptedKey.textContent, 'base64');
+  const decrypted = crypto.privateDecrypt({ key: options.key, padding, oaepHash}, key);
   return Buffer.from(decrypted, 'binary');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xml-encryption",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xml-encryption",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.5",
@@ -17,9 +17,6 @@
         "mocha": "^7.1.2",
         "should": "^11.2.1",
         "sinon": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@sinonjs/commons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "mocha": "^7.1.2",
-        "should": "^11.2.1",
         "sinon": "^9.0.2"
       }
     },
@@ -1179,66 +1178,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/should": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
-      "integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-equal": "^1.0.0",
-        "should-format": "^3.0.2",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
-      "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.0.0"
-      }
-    },
-    "node_modules/should-format": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
-      }
-    },
-    "node_modules/should-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/should-type-adaptors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
-      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/sinon": {
       "version": "9.0.2",
@@ -2409,60 +2348,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "should": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
-      "integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
-      "dev": true,
-      "requires": {
-        "should-equal": "^1.0.0",
-        "should-format": "^3.0.2",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
-      }
-    },
-    "should-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
-      "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.0.0"
-      }
-    },
-    "should-format": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
-      }
-    },
-    "should-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
-      "dev": true
-    },
-    "should-type-adaptors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
-      }
-    },
-    "should-util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
-      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
     },
     "sinon": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.1.0",
   "devDependencies": {
     "mocha": "^7.1.2",
-    "should": "^11.2.1",
     "sinon": "^9.0.2"
   },
   "main": "./lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xml-encryption",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "devDependencies": {
     "mocha": "^7.1.2",
     "should": "^11.2.1",
@@ -30,8 +30,5 @@
   ],
   "scripts": {
     "test": "mocha"
-  },
-  "engines": {
-    "node": ">=12 < 18"
   }
 }

--- a/test/xmlenc.encryptedkey.js
+++ b/test/xmlenc.encryptedkey.js
@@ -1,9 +1,7 @@
 var assert = require('assert');
 var fs = require('fs');
-var should = require('should');
 var sinon = require('sinon');
 var xmlenc = require('../lib');
-var xpath = require('xpath');
 
 describe('encrypt', function() {
   let consoleSpy = null;
@@ -39,6 +37,21 @@ describe('encrypt', function() {
       encryptionAlgorithm: 'http://www.w3.org/2009/xmlenc11#aes128-gcm',
       keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
     }
+  },
+  {
+    name: 'aes-128-gcm with sha256',
+    encryptionOptions: {
+      encryptionAlgorithm: 'http://www.w3.org/2009/xmlenc11#aes128-gcm',
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+      keyEncryptionDigest: 'sha256'
+    }
+  }, {
+    name: 'aes-128-gcm with sha512',
+    encryptionOptions: {
+      encryptionAlgorithm: 'http://www.w3.org/2009/xmlenc11#aes128-gcm',
+      keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+      keyEncryptionDigest: 'sha512'
+    }
   }, {
     name: 'des-ede3-cbc',
     encryptionOptions: {
@@ -72,6 +85,7 @@ describe('encrypt', function() {
 
     xmlenc.encrypt(content, options, function(err, result) {
       xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key'), warnInsecureAlgorithm: false}, function (err, decrypted) {
+        if (err) return done(err);
         assert.equal(decrypted, content);
         done();
       });
@@ -92,7 +106,7 @@ describe('encrypt', function() {
         assert(err);
         assert(!result);
         //should not pop up warns due to options.warnInsecureAlgorithm = false;
-        consoleSpy.called.should.equal(false);
+        assert.equal(consoleSpy.called, false);
         done();
       });
     });
@@ -222,7 +236,7 @@ describe('encrypt', function() {
 
     xmlenc.encryptKeyInfo(plaintext, options, function(err, encryptedKeyInfo) {
       if (err) return done(err);
-      consoleSpy.called.should.equal(true);
+      assert.equal(consoleSpy.called, true);
       assert.throws(
         function(){xmlenc.decryptKeyInfo(
           encryptedKeyInfo,


### PR DESCRIPTION
Add support for encryption key OAEP digest method using `http://www.w3.org/2000/09/xmldsig#sha256` and `http://www.w3.org/2000/09/xmldsig#sha512` in addition to SHA1.