### PR TITLE
ci: switch to conventionalcommits preset for semantic-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -38,8 +38,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Run semantic-release with only commit analyzer to detect version
-          NEXT_VERSION=$(npx semantic-release --dry-run --plugins @semantic-release/commit-analyzer | tee /dev/stderr | awk '/The next release version is/{print $NF}')
+          # Run semantic-release with dry-run to detect version
+          NEXT_VERSION=$(npx semantic-release --dry-run --verify-conditions false | tee /dev/stderr | awk '/The next release version is/{print $NF}')
           echo "next=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update package.json

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,18 @@
 {
   "branches": ["master"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     [
       "@semantic-release/npm",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@commitlint/cli": "^20.3.1",
         "@commitlint/config-conventional": "^20.3.1",
         "@semantic-release/exec": "^7.0.3",
+        "conventional-changelog-conventionalcommits": "^9.3.0",
         "husky": "^9.1.7",
         "mocha": "^7.1.2",
         "semantic-release": "^25.0.2",
@@ -308,6 +309,19 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -2583,16 +2597,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {
@@ -9169,6 +9183,17 @@
       "requires": {
         "@commitlint/types": "^20.3.1",
         "conventional-changelog-conventionalcommits": "^7.0.2"
+      },
+      "dependencies": {
+        "conventional-changelog-conventionalcommits": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+          "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+          "dev": true,
+          "requires": {
+            "compare-func": "^2.0.0"
+          }
+        }
       }
     },
     "@commitlint/config-validator": {
@@ -10698,9 +10723,9 @@
       }
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
     "@semantic-release/exec": "^7.0.3",
+    "conventional-changelog-conventionalcommits": "^9.3.0",
     "husky": "^9.1.7",
     "mocha": "^7.1.2",
     "semantic-release": "^25.0.2",


### PR DESCRIPTION
By submitting a PR to this repository, I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

- Switch `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` to use the `conventionalcommits` preset, enabling `feat!` notation for breaking changes
- Replace semantic-release dry-run version detection in prepare-release workflow with `semantic-release --dry-run --verify-conditions false` to avoid token requirements while correctly detecting versions
- Update changelog generation in prepare-release workflow to use `conventionalcommits` preset


### Testing

```
npx semantic-release --dry-run --verify-conditions false --branches "ci/conventional-commits"
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
