### PR TITLE
chore: load templates with explicit extensions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,3 @@
-var path = require('path'),
-    fs = require('fs');
-
 var templates = {
   'encrypted-key': require('./templates/encrypted-key.tpl.xml'),
   'keyinfo': require('./templates/keyinfo.tpl.xml'),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 var templates = {
-  'encrypted-key': require('./templates/encrypted-key.tpl.xml'),
-  'keyinfo': require('./templates/keyinfo.tpl.xml'),
+  'encrypted-key': require('./templates/encrypted-key.tpl.xml.js'),
+  'keyinfo': require('./templates/keyinfo.tpl.xml.js'),
 };
 
 function renderTemplate(file, data) {


### PR DESCRIPTION
### Description

I am trying to use this library in the context of expo server routes, which seems to use Metro's [module resolution](https://metrobundler.dev/docs/resolution), which does introduce special [asset extensions](https://metrobundler.dev/docs/resolution/#assetexts-readonlysetstring) which change the way modules are loaded for certain extensions (including [xml](https://github.com/facebook/metro/blob/877b64ea596730e0ff50001c50943a243aa2f31e/packages/metro-config/src/defaults/defaults.js#L26)).

All of that is to say, that when someone tries to load this library in expo, you get this error:

```bash
Metro error: Unable to resolve module ./templates/encrypted-key.tpl.xml from /Users/jonathansamines/dev/my-app/node_modules/@authenio/xml-encryption/lib/utils.js:

None of these files exist:
  * encrypted-key.tpl.xml
  * node_modules/@authenio/xml-encryption/lib/templates/encrypted-key.tpl.xml
  3 |
  4 | var templates = {
> 5 |   'encrypted-key': require('./templates/encrypted-key.tpl.xml'),
    |                             ^
  6 |   'keyinfo': require('./templates/keyinfo.tpl.xml'),
  7 | };
  8 |
```

I realize this library was probably not designed for environments such as expo, but I am pulling this library transitively in a way that it gets loaded but not used, so at least being able to load it would be nice.

### References
N/A

### Testing

All tests pass

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
