### PR TITLE
BREAKING CHANGE: Fix digest method algorithm id

### DIFF
--- a/lib/templates/keyinfo.tpl.xml.js
+++ b/lib/templates/keyinfo.tpl.xml.js
@@ -1,10 +1,21 @@
 var escapehtml = require('escape-html');
 
-module.exports = ({ encryptionPublicCert, encryptedKey, keyEncryptionMethod, keyEncryptionDigest }) => `
+const DIGEST_ALGORITHMS = {
+    'sha1': 'http://www.w3.org/2000/09/xmldsig#sha1',
+    'sha256': 'http://www.w3.org/2001/04/xmlenc#sha256',
+    'sha512': 'http://www.w3.org/2001/04/xmlenc#sha512'
+};
+
+module.exports = ({ encryptionPublicCert, encryptedKey, keyEncryptionMethod, keyEncryptionDigest }) => {
+    const digestUri = DIGEST_ALGORITHMS[keyEncryptionDigest] || keyEncryptionDigest;
+
+    // RSA-OAEP requires it. RSA-1.5 must NOT have it.
+    const isOAEP = keyEncryptionMethod && keyEncryptionMethod.includes('rsa-oaep');
+    return `
 <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
   <e:EncryptedKey xmlns:e="http://www.w3.org/2001/04/xmlenc#">
     <e:EncryptionMethod Algorithm="${escapehtml(keyEncryptionMethod)}">
-      <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#${escapehtml(keyEncryptionDigest)}" />
+      ${isOAEP ? `<DigestMethod Algorithm="${escapehtml(digestUri)}" />` : ''}
     </e:EncryptionMethod>
     <KeyInfo>
       ${encryptionPublicCert}
@@ -15,4 +26,4 @@ module.exports = ({ encryptionPublicCert, encryptedKey, keyEncryptionMethod, key
   </e:EncryptedKey>
 </KeyInfo>
 `;
-
+}

--- a/lib/templates/keyinfo.tpl.xml.js
+++ b/lib/templates/keyinfo.tpl.xml.js
@@ -1,6 +1,7 @@
 var escapehtml = require('escape-html');
 
 const DIGEST_ALGORITHMS = {
+    // SHA-2 was published after 2000/09/xmldsig was locked, so sha256/sha512 live under 2001/04/xmlenc.
     'sha1': 'http://www.w3.org/2000/09/xmldsig#sha1',
     'sha256': 'http://www.w3.org/2001/04/xmlenc#sha256',
     'sha512': 'http://www.w3.org/2001/04/xmlenc#sha512'
@@ -9,7 +10,7 @@ const DIGEST_ALGORITHMS = {
 module.exports = ({ encryptionPublicCert, encryptedKey, keyEncryptionMethod, keyEncryptionDigest }) => {
     const digestUri = DIGEST_ALGORITHMS[keyEncryptionDigest] || keyEncryptionDigest;
 
-    // RSA-OAEP requires it. RSA-1.5 must NOT have it.
+    // RSA-1.5 doesn't hash the key, so it has no digest or DigestMethod. RSA-OAEP does.
     const isOAEP = keyEncryptionMethod && keyEncryptionMethod.includes('rsa-oaep');
     return `
 <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">

--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -255,9 +255,11 @@ function decryptKeyInfo(doc, options) {
   if (keyDigestMethod) {
     const keyDigestMethodAlgorithm = keyDigestMethod.getAttribute('Algorithm');
     switch (keyDigestMethodAlgorithm) {
-      case 'http://www.w3.org/2000/09/xmldsig#sha256':
+      case 'http://www.w3.org/2001/04/xmlenc#sha256':
+      case 'http://www.w3.org/2000/09/xmldsig#sha256': // backwards compatibility for previous wrong usage
         oaepHash = 'sha256';
         break;
+      case 'http://www.w3.org/2001/04/xmlenc#sha512':
       case 'http://www.w3.org/2000/09/xmldsig#sha512':
         oaepHash = 'sha512';
         break;

--- a/lib/xmlenc.js
+++ b/lib/xmlenc.js
@@ -260,7 +260,7 @@ function decryptKeyInfo(doc, options) {
         oaepHash = 'sha256';
         break;
       case 'http://www.w3.org/2001/04/xmlenc#sha512':
-      case 'http://www.w3.org/2000/09/xmldsig#sha512':
+      case 'http://www.w3.org/2000/09/xmldsig#sha512': // backwards compatibility for previous wrong usage
         oaepHash = 'sha512';
         break;
     }

--- a/test/xmlenc.digest.js
+++ b/test/xmlenc.digest.js
@@ -1,0 +1,136 @@
+var assert = require('assert');
+var fs = require('fs');
+var xmlenc = require('../lib');
+var keyinfoTemplate = require('../lib/templates/keyinfo.tpl.xml');
+
+var RSA_OAEP = 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p';
+var RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5';
+
+describe('keyEncryptionDigest', function () {
+
+  describe('keyinfo template DigestMethod', function () {
+    function render(overrides) {
+      return keyinfoTemplate(Object.assign({
+        encryptionPublicCert: '<X509Data></X509Data>',
+        encryptedKey: 'ZW5jcnlwdGVkS2V5',
+        keyEncryptionMethod: RSA_OAEP,
+        keyEncryptionDigest: 'sha1'
+      }, overrides));
+    }
+
+    it('maps sha1 to the xmldsig sha1 URI', function () {
+      var xml = render({ keyEncryptionDigest: 'sha1' });
+      assert(xml.includes('<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />'));
+    });
+
+    it('maps sha256 to the xmlenc sha256 URI', function () {
+      var xml = render({ keyEncryptionDigest: 'sha256' });
+      assert(xml.includes('<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />'));
+    });
+
+    it('maps sha512 to the xmlenc sha512 URI', function () {
+      var xml = render({ keyEncryptionDigest: 'sha512' });
+      assert(xml.includes('<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512" />'));
+    });
+
+    it('passes through an unknown digest value unchanged', function () {
+      var custom = 'http://example.org/custom#sha3-256';
+      var xml = render({ keyEncryptionDigest: custom });
+      assert(xml.includes('<DigestMethod Algorithm="' + custom + '" />'));
+    });
+
+    it('includes a DigestMethod for RSA-OAEP', function () {
+      var xml = render({ keyEncryptionMethod: RSA_OAEP, keyEncryptionDigest: 'sha256' });
+      assert(xml.includes('<DigestMethod'));
+    });
+
+    it('does NOT include a DigestMethod for RSA-1.5', function () {
+      var xml = render({ keyEncryptionMethod: RSA_1_5, keyEncryptionDigest: 'sha256' });
+      assert(!xml.includes('<DigestMethod'));
+    });
+  });
+
+  describe('encrypt/decrypt round trip with digest', function () {
+    function baseOptions() {
+      return {
+        rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+        pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
+        key: fs.readFileSync(__dirname + '/test-auth0.key'),
+        encryptionAlgorithm: 'http://www.w3.org/2009/xmlenc11#aes256-gcm',
+        keyEncryptionAlgorithm: RSA_OAEP
+      };
+    }
+
+    ['sha1', 'sha256', 'sha512'].forEach(function (digest) {
+      it('round trips with ' + digest, function (done) {
+        var options = baseOptions();
+        options.keyEncryptionDigest = digest;
+        var content = 'content encrypted with ' + digest;
+
+        xmlenc.encrypt(content, options, function (err, result) {
+          if (err) return done(err);
+          xmlenc.decrypt(result, { key: fs.readFileSync(__dirname + '/test-auth0.key') }, function (err, decrypted) {
+            if (err) return done(err);
+            assert.equal(decrypted, content);
+            done();
+          });
+        });
+      });
+    });
+
+    it('emits the correct xmlenc URI in the produced XML for sha256', function (done) {
+      var options = baseOptions();
+      options.keyEncryptionDigest = 'sha256';
+      xmlenc.encrypt('content', options, function (err, result) {
+        if (err) return done(err);
+        assert(result.includes('http://www.w3.org/2001/04/xmlenc#sha256'));
+        assert(!result.includes('http://www.w3.org/2000/09/xmldsig#sha256'));
+        done();
+      });
+    });
+  });
+
+  describe('decrypt backwards compatibility with old (wrong) xmldsig digest URIs', function () {
+    function encryptWith(digest, cb) {
+      var options = {
+        rsa_pub: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+        pem: fs.readFileSync(__dirname + '/test-auth0.pem'),
+        key: fs.readFileSync(__dirname + '/test-auth0.key'),
+        encryptionAlgorithm: 'http://www.w3.org/2009/xmlenc11#aes256-gcm',
+        keyEncryptionAlgorithm: RSA_OAEP,
+        keyEncryptionDigest: digest
+      };
+      xmlenc.encrypt('legacy digest content', options, cb);
+    }
+
+    it('decrypts a document using the legacy xmldsig#sha256 URI', function (done) {
+      encryptWith('sha256', function (err, result) {
+        if (err) return done(err);
+        var legacy = result.replace(
+          'http://www.w3.org/2001/04/xmlenc#sha256',
+          'http://www.w3.org/2000/09/xmldsig#sha256'
+        );
+        xmlenc.decrypt(legacy, { key: fs.readFileSync(__dirname + '/test-auth0.key') }, function (err, decrypted) {
+          if (err) return done(err);
+          assert.equal(decrypted, 'legacy digest content');
+          done();
+        });
+      });
+    });
+
+    it('decrypts a document using the legacy xmldsig#sha512 URI', function (done) {
+      encryptWith('sha512', function (err, result) {
+        if (err) return done(err);
+        var legacy = result.replace(
+          'http://www.w3.org/2001/04/xmlenc#sha512',
+          'http://www.w3.org/2000/09/xmldsig#sha512'
+        );
+        xmlenc.decrypt(legacy, { key: fs.readFileSync(__dirname + '/test-auth0.key') }, function (err, decrypted) {
+          if (err) return done(err);
+          assert.equal(decrypted, 'legacy digest content');
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/xmlenc.digest.js
+++ b/test/xmlenc.digest.js
@@ -39,11 +39,6 @@ describe('keyEncryptionDigest', function () {
       assert(xml.includes('<DigestMethod Algorithm="' + custom + '" />'));
     });
 
-    it('includes a DigestMethod for RSA-OAEP', function () {
-      var xml = render({ keyEncryptionMethod: RSA_OAEP, keyEncryptionDigest: 'sha256' });
-      assert(xml.includes('<DigestMethod'));
-    });
-
     it('does NOT include a DigestMethod for RSA-1.5', function () {
       var xml = render({ keyEncryptionMethod: RSA_1_5, keyEncryptionDigest: 'sha256' });
       assert(!xml.includes('<DigestMethod'));
@@ -78,6 +73,16 @@ describe('keyEncryptionDigest', function () {
       });
     });
 
+    it('emits the correct xmldsig URI in the produced XML for sha1', function (done) {
+      var options = baseOptions();
+      options.keyEncryptionDigest = 'sha1';
+      xmlenc.encrypt('content', options, function (err, result) {
+        if (err) return done(err);
+        assert(result.includes('http://www.w3.org/2000/09/xmldsig#sha1'));
+        done();
+      });
+    });
+
     it('emits the correct xmlenc URI in the produced XML for sha256', function (done) {
       var options = baseOptions();
       options.keyEncryptionDigest = 'sha256';
@@ -85,6 +90,17 @@ describe('keyEncryptionDigest', function () {
         if (err) return done(err);
         assert(result.includes('http://www.w3.org/2001/04/xmlenc#sha256'));
         assert(!result.includes('http://www.w3.org/2000/09/xmldsig#sha256'));
+        done();
+      });
+    });
+
+    it('emits the correct xmlenc URI in the produced XML for sha512', function (done) {
+      var options = baseOptions();
+      options.keyEncryptionDigest = 'sha512';
+      xmlenc.encrypt('content', options, function (err, result) {
+        if (err) return done(err);
+        assert(result.includes('http://www.w3.org/2001/04/xmlenc#sha512'));
+        assert(!result.includes('http://www.w3.org/2000/09/xmldsig#sha512'));
         done();
       });
     });


### PR DESCRIPTION
### Description

Replaces https://github.com/auth0/node-xml-encryption/pull/118

`http://www.w3.org/2000/09/xmldsig#sha256` and `http://www.w3.org/2000/09/xmldsig#sha512` are not valid DigestMethod algorithm values, the correct DigestMethod algorithm identifier’s should be `http://www.w3.org/2001/04/xmlenc#sha256` and `http://www.w3.org/2001/04/xmlenc#sha512`. (see [XML Encryption Syntax and Processing Version 1.1](https://www.w3.org/TR/xmlenc-core1/#sec-SHA256) )

Update the decryption logic to support the new `2001/04/xmlenc` identifiers for encryption and decryption and the existing `2000/09/xmldsig` identifiers for decryption (for backwards compatibility)

This is a breaking change for people doing `rsa-oaep` with `sha256` or `sha512`

### References

https://www.w3.org/TR/xmlenc-core1/#sec-SHA256

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
